### PR TITLE
chore: project initialization - sync labels.json

### DIFF
--- a/.github/.labels.json
+++ b/.github/.labels.json
@@ -142,5 +142,11 @@
         "color": "5319e7",
         "default": false,
         "description": "User story"
+    },
+    {
+        "name": "implementation:ready",
+        "color": "1d76db",
+        "default": false,
+        "description": "Implementation plan is ready for execution"
     }
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -425,3 +425,6 @@ docker/validation/results.jsonl
 docker/.env
 models.json
 test-results-pester.xml
+
+# Generated orchestrator prompt (runtime artifact)
+.assembled-orchestrator-prompt.md


### PR DESCRIPTION
## Summary
- Add `implementation:ready` label definition to `.github/.labels.json`
- This ensures the source of truth for repository labels is complete

## Context
This PR is part of the `init-existing-repository` assignment for project-setup workflow.

## Changes
- Added `implementation:ready` label with color `1d76db` and description "Implementation plan is ready for execution"

## Verification
- Labels already synced to repository
- Source of truth file now matches repository state